### PR TITLE
fix(code): fix inconsistent font-size of the inline code elements within headers

### DIFF
--- a/mint.css
+++ b/mint.css
@@ -311,6 +311,15 @@ hr {
 	margin: 0 2px;
 }
 
+#write h1 code,
+#write h2 code,
+#write h3 code,
+#write h4 code,
+#write h5 code,
+#write h6 code {
+    font-size: inherit;
+}
+
 /*footnote*/
 #write .md-footnote {
 	color: #777777;


### PR DESCRIPTION
if you use some inline codes within a header block (e.g. # Here is an `inline code`), the font size
of the inline codes will still be 0.9rem other than the inherent value from the father element (i.e.
the header block). To fix this bad style, I explicitly define the font-size style of inline codes to
use the inherent value when inline codes are within headers.